### PR TITLE
Preferovat jednodušší způsob jak přidat informace o Pyvu

### DIFF
--- a/.github/workflows/prague.yml
+++ b/.github/workflows/prague.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Install dependencies
       run: python -m pip install -r requirements.txt
     - name: Run
-      run: python jechova.py '#pyvo-praha' https://pyvo.cz/api/series/praha-pyvo.ics
+      run: python jechova.py '#pyvo-praha' praha-pyvo
       env:
         SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ $ python jechova.py '#pyvo-praha' praha-pyvo
 First argument is a channel name where the message should go. Beware, if you specify it as `#pyvo-praha`, standard shell interprets the `#` as a start of a comment and will ignore the rest of the line. You must pass it either as `pyvo-praha` or as `'#pyvo-praha'` (both works).
 
 Second argument is the meetup slug used in URLs for calendars and meetups, such as `praha-pyvo`.
-(Deprecated: it can also be the URL for the ics feed; the message won't be as nice if you use that.).
 
 When debugging, force sending of the message by adding `-f`. (And use `#automatizace` or other less populated channel.)
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ Checks whether the next meetup is announced on [pyvo.cz](https://pyvo.cz/). If n
 
 ```bash
 $ export SLACK_API_TOKEN=...
-$ python jechova.py '#pyvo-praha' https://pyvo.cz/api/series/praha-pyvo.ics
+$ python jechova.py '#pyvo-praha' praha-pyvo
 ```
 
 First argument is a channel name where the message should go. Beware, if you specify it as `#pyvo-praha`, standard shell interprets the `#` as a start of a comment and will ignore the rest of the line. You must pass it either as `pyvo-praha` or as `'#pyvo-praha'` (both works).
 
-Second argument is the source ics feed for the Pyvo meetup you want to watch. Each meetup tracked on pyvo.cz has the ics feed automatically generated, you can find a link somewhere on the meetup page (e.g. somewhere on [pyvo.cz/praha-pyvo](https://pyvo.cz/praha-pyvo/)).
+Second argument is the meetup slug used in URLs for calendars and meetups, such as `praha-pyvo`.
+(Deprecated: it can also be the URL for the ics feed; the message won't be as nice if you use that.).
 
 When debugging, force sending of the message by adding `-f`. (And use `#automatizace` or other less populated channel.)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ python jechova.py '#pyvo-praha' praha-pyvo
 
 First argument is a channel name where the message should go. Beware, if you specify it as `#pyvo-praha`, standard shell interprets the `#` as a start of a comment and will ignore the rest of the line. You must pass it either as `pyvo-praha` or as `'#pyvo-praha'` (both works).
 
-Second argument is the meetup slug used in URLs for calendars and meetups, such as `praha-pyvo`.
+Second argument is the meetup slug used in the meetup URL. For example, if the meetup URL is `https://pyvo.cz/praha-pyvo/`, the slug would be `praha-pyvo`.
 
 When debugging, force sending of the message by adding `-f`. (And use `#automatizace` or other less populated channel.)
 

--- a/jechova.py
+++ b/jechova.py
@@ -17,10 +17,18 @@ if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--force', '-f', action='store_true')
     parser.add_argument('channel')
-    parser.add_argument('ics_url')
+    parser.add_argument('pyvo_slug')
     args = parser.parse_args()
 
-    response = requests.get(args.ics_url)
+    if '/' in args.pyvo_slug:
+        # Deprecated: We accept an ICS URL instead of just a slug
+        ics_url = args.pyvo_slug
+        web_url = None
+    else:
+        ics_url = f'https://pyvo.cz/api/series/{args.pyvo_slug}.ics'
+        web_url = f'https://pyvo.cz/{args.pyvo_slug}/'
+
+    response = requests.get(ics_url)
     response.raise_for_status()
     calendar = Calendar(response.text)
 
@@ -41,9 +49,18 @@ if __name__ == '__main__':
 
     channel = '#' + args.channel.lstrip('#')
     client = WebClient(token=os.environ['SLACK_API_TOKEN'])
-    client.chat_postMessage(channel=channel, text=dedent('''
-        Máte téma? A mohla bych ho vidět? :eyes:\n\n
-        Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz — může
-        to udělat kdokoliv, v 5 jednoduchých krocích:
-        https://docs.pyvec.org/guides/meetup.html#informace-na-pyvo-cz
-    ''').strip())
+    if web_url:
+        client.chat_postMessage(channel=channel, text=dedent(f'''
+            Máte téma? A mohla bych ho vidět? :eyes:\n\n
+            Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz — nejlépe
+            přes tlačítko _přidat informace o dalším srazu_ na <{web_url}>.
+
+            (Existuje i <https://docs.pyvec.org/guides/meetup.html#informace-na-pyvo-cz|podrobnější návod>.)
+        ''').strip())
+    else:
+        client.chat_postMessage(channel=channel, text=dedent('''
+            Máte téma? A mohla bych ho vidět? :eyes:\n\n
+            Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz — může
+            to udělat kdokoliv, v 5 jednoduchých krocích:
+            https://docs.pyvec.org/guides/meetup.html#informace-na-pyvo-cz
+        ''').strip())

--- a/jechova.py
+++ b/jechova.py
@@ -2,7 +2,6 @@ from argparse import ArgumentParser
 import os
 import sys
 from operator import attrgetter
-from textwrap import dedent
 
 import arrow
 from ics import Calendar
@@ -21,14 +20,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if '/' in args.pyvo_slug:
-        # Deprecated: We accept an ICS URL instead of just a slug
-        ics_url = args.pyvo_slug
-        web_url = None
-    else:
-        ics_url = f'https://pyvo.cz/api/series/{args.pyvo_slug}.ics'
-        web_url = f'https://pyvo.cz/{args.pyvo_slug}/'
+        raise ValueError(
+            "Meetup slug cannot contain slashes. See the README for usage."
+        )
 
-    response = requests.get(ics_url)
+    response = requests.get(f'https://pyvo.cz/api/series/{args.pyvo_slug}.ics')
     response.raise_for_status()
     calendar = Calendar(response.text)
 
@@ -51,18 +47,11 @@ if __name__ == '__main__':
     client = WebClient(token=os.environ['SLACK_API_TOKEN'])
 
     docs_url = "https://docs.pyvec.org/guides/meetup.html#informace-na-pyvo-cz"
-    if web_url:
-        client.chat_postMessage(channel=channel, text=dedent(f'''
-            Máte téma? A mohla bych ho vidět? :eyes:\n\n
-            Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz — nejlépe
-            přes tlačítko _přidat informace o dalším srazu_ na <{web_url}>.
-
-            (Existuje i <{docs_url}|podrobnější návod>.)
-        ''').strip())
-    else:
-        client.chat_postMessage(channel=channel, text=dedent(f'''
-            Máte téma? A mohla bych ho vidět? :eyes:\n\n
-            Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz — může
-            to udělat kdokoliv, v 5 jednoduchých krocích:
-            {docs_url}
-        ''').strip())
+    web_url = f'https://pyvo.cz/{args.pyvo_slug}/'
+    client.chat_postMessage(channel=channel, text=' '.join((
+        'Máte téma? A mohla bych ho vidět? :eyes:\n',
+        'Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz',
+        'přes odkaz _přidat informace o dalším srazu_ na',
+        f'<{web_url}|pyvo.cz/{args.pyvo_slug}>.\n',
+        '(Složitější případy řešte v <#C97Q9HHHT>)',
+    )))

--- a/jechova.py
+++ b/jechova.py
@@ -49,18 +49,20 @@ if __name__ == '__main__':
 
     channel = '#' + args.channel.lstrip('#')
     client = WebClient(token=os.environ['SLACK_API_TOKEN'])
+
+    docs_url = "https://docs.pyvec.org/guides/meetup.html#informace-na-pyvo-cz"
     if web_url:
         client.chat_postMessage(channel=channel, text=dedent(f'''
             Máte téma? A mohla bych ho vidět? :eyes:\n\n
             Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz — nejlépe
             přes tlačítko _přidat informace o dalším srazu_ na <{web_url}>.
 
-            (Existuje i <https://docs.pyvec.org/guides/meetup.html#informace-na-pyvo-cz|podrobnější návod>.)
+            (Existuje i <{docs_url}|podrobnější návod>.)
         ''').strip())
     else:
-        client.chat_postMessage(channel=channel, text=dedent('''
+        client.chat_postMessage(channel=channel, text=dedent(f'''
             Máte téma? A mohla bych ho vidět? :eyes:\n\n
             Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz — může
             to udělat kdokoliv, v 5 jednoduchých krocích:
-            https://docs.pyvec.org/guides/meetup.html#informace-na-pyvo-cz
+            {docs_url}
         ''').strip())

--- a/jechova.py
+++ b/jechova.py
@@ -53,5 +53,5 @@ if __name__ == '__main__':
         'Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz',
         'přes odkaz _přidat informace o dalším srazu_ na',
         f'<{web_url}|pyvo.cz/{args.pyvo_slug}>.\n',
-        '(Složitější případy řešte v <#C97Q9HHHT>)',  # makes a link to the #pyvo channel
+        '(Složitější případy řešte v <#C97Q9HHHT>)',  # links to #pyvo channel
     )))

--- a/jechova.py
+++ b/jechova.py
@@ -53,5 +53,5 @@ if __name__ == '__main__':
         'Pokud už tušíte, o čem Pyvo bude, přidejte to na pyvo.cz',
         'přes odkaz _přidat informace o dalším srazu_ na',
         f'<{web_url}|pyvo.cz/{args.pyvo_slug}>.\n',
-        '(Složitější případy řešte v <#C97Q9HHHT>)',
+        '(Složitější případy řešte v <#C97Q9HHHT>)',  # makes a link to the #pyvo channel
     )))


### PR DESCRIPTION
Dobrý den, paní Jechová,

Na stránkách pyvo.cz je teď odkaz, přes který se dá přidat nové Pyvo snadno a rychle. Jen o tom nikdo neví. Mohla byste tuto informaci roznést po pavlačích?

Bohužel se k tomu budete potřebovat naučit brát jiný *argument*, ale doufám, že to zvládnete.